### PR TITLE
Updates Game Options configuration for Custom Lawset.

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -347,7 +347,7 @@ NEAR_DEATH_EXPERIENCE
 ## Set to 1 for "custom", silicons will start with the custom laws defined in silicon_laws.txt. (If silicon_laws.txt is empty, the AI will spawn with asimov and Custom boards will auto-delete.)
 ## Set to 2 for "random", silicons will start with a random lawset picked from random laws specified below.
 ## Set to 3 for "weighted random", using values in "silicon_weights.txt", a law will be selected, with weights specifed in that file.
-DEFAULT_LAWS 0
+DEFAULT_LAWS 1
 
 ## RANDOM LAWS ##
 ## ------------------------------------------------------------------------------------------


### PR DESCRIPTION
This updates the game_options configuration text file A.I lawset default. By default it's configured for 0 which automatically uses Asimov lawset.
I've set it to 1 which will use the laws in Silicon_Laws.txt, this commit alone will do nothing as the default laws for Silicon_Laws.txt are Asimov, however I intend to pull a modified version of Openss13 based laws for Star Trek 13.


[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
